### PR TITLE
fix: polygon and foliage shader mapping/detection corrections

### DIFF
--- a/shader_mapping.py
+++ b/shader_mapping.py
@@ -850,6 +850,7 @@ COLOR_MAP_FOLIAGE: dict[str, str] = {
     "_Leaf_Base_Color": "leaf_base_color",
     "_Trunk_Base_Color": "trunk_base_color",
     "_Leaf_Noise_Color": "leaf_noise_color",
+    "_Leaf_Noise_Large_Color": "leaf_noise_large_color",
     "_Trunk_Noise_Color": "trunk_noise_color",
     "_Emissive_Color": "emissive_color",
     "_Emissive_2_Color": "emissive_2_color",
@@ -1101,6 +1102,7 @@ ALPHA_FIX_PROPERTIES: set[str] = {
     "_Color_BodyArt",
     # Foliage noise colors
     "_Leaf_Noise_Color",
+    "_Leaf_Noise_Large_Color",
     "_Trunk_Noise_Color",
 }
 
@@ -1518,7 +1520,8 @@ def detect_shader_type(
         }
         foliage_color_props = {
             "_Leaf_Base_Color", "_Trunk_Base_Color", "_Leaf_Noise_Color",
-            "_Trunk_Noise_Color", "_Frosting_Color", "_Trunk_Emissive_Color"
+            "_Leaf_Noise_Large_Color", "_Trunk_Noise_Color",
+            "_Frosting_Color", "_Trunk_Emissive_Color"
         }
         foliage_props = sum(1 for p in foliage_float_props if p in floats)
         foliage_props += sum(1 for p in foliage_color_props if p in colors)

--- a/shader_mapping.py
+++ b/shader_mapping.py
@@ -862,12 +862,17 @@ COLOR_MAP_FOLIAGE: dict[str, str] = {
 COLOR_MAP_POLYGON: dict[str, str] = {
     # Base color/tint
     "_Color_Tint": "color_tint",
+    "_ColorTint": "color_tint",  # Synty's most common form (no underscore)
     "_Color": "color_tint",
     "_BaseColor": "color_tint",
     "_BaseColour": "color_tint",
-    # Emission
-    "_Emission_Color": "emission_color",
-    "_EmissionColor": "emission_color",
+    # Emission — polygon.gdshader's uniform is `emission_color_tint`,
+    # not `emission_color`. Writing the wrong shader_parameter name causes
+    # Godot to fall back to the shader's built-in default (vec4(1.0) / full
+    # white emission), which makes any material with an emission texture
+    # glow pure white regardless of the Unity _EmissionColor value.
+    "_Emission_Color": "emission_color_tint",
+    "_EmissionColor": "emission_color_tint",
     # Snow overlay
     "_Snow_Color": "snow_color",
     # Character colors (hair/skin)

--- a/shader_mapping.py
+++ b/shader_mapping.py
@@ -329,7 +329,7 @@ SHADER_NAME_PATTERNS_SCORED: list[tuple[re.Pattern[str], str, int]] = [
     # --------------------------------------------------------------------------
     # These are common in compound names and shouldn't override more specific
     # technical terms. "Dirt_Leaves_Triplanar" should use polygon, not foliage.
-    (re.compile(r"(?i)(tree|fern|grass|vine|branch|willow|bush|shrub|hedge|bamboo|koru|treefern)"), "foliage.gdshader", 25),
+    (re.compile(r"(?i)(tree|fern|grass|vine|branch|willow|bush|shrub|hedge|bamboo|koru|treefern|flower|sunflower|wildflower|cropfield|crop|cover|card_|kite|leaves)"), "foliage.gdshader", 25),
     (re.compile(r"(?i)(leaf|leaves)"), "foliage.gdshader", 20),  # Very common, low priority
     (re.compile(r"(?i)(bark|trunk|undergrowth|plant)"), "foliage.gdshader", 20),
 


### PR DESCRIPTION
## Summary

Three independent fixes in `shader_mapping.py` that caused converted Synty
materials to render incorrectly out of the box. All found while integrating
POLYGON Nature and Meadow Forest into a Godot 4.6 project — patched 30+
materials downstream before tracking the root causes.

## Bug 1 — `COLOR_MAP_POLYGON`: `_ColorTint` not mapped, emission uniform name wrong

The dict had `_Color_Tint` (with underscore between `Color` and `Tint`), but
many Synty `.mat` files use the contiguous spelling `_ColorTint`. The converter
silently dropped that key, leaving every output material's `color_tint`
parameter at the shader default `(1, 1, 1, 1)` white. Result: leaves and
plants that rely on a non-white tint to colorize their grayscale base texture
render almost pure white.

Separately, `_EmissionColor` and `_Emission_Color` both mapped to
`emission_color`, but the polygon shader bundled here (`shaders/polygon.gdshader`)
declares its uniform as **`emission_color_tint`**. When Godot loads a material
with a `shader_parameter/<name>` that doesn't match a real uniform, it falls
back to the shader's built-in default — `vec4(1.0)`, full white emission. Any
polygon-shader material with an emission texture (leaves, butterflies, FX)
ended up glowing pure white regardless of the Unity value.

## Bug 2 — `COLOR_MAP_FOLIAGE`: `_Leaf_Noise_Large_Color` not mapped

The foliage shader's leaf-tint mixing uses three uniforms:

```
small = mix(leaf_noise_color, leaf_base_color, small_noise_level)
final = mix(small, leaf_noise_large_color, large_noise_level)
```

`_Leaf_Base_Color` and `_Leaf_Noise_Color` were already in `COLOR_MAP_FOLIAGE`,
but `_Leaf_Noise_Large_Color` was missing. The converter emitted the shader
default `vec4(1.0)` even when the Unity `.mat` had a non-white value. Visually
the leaves rendered with white patches in regions where `large_noise_level`
was high.

Reproducer: Meadow Forest's `Card_Tree_Birch_02` material has
`_Leaf_Noise_Large_Color` set to yellow `(0.82, 0.69, 0)` — converted output
was pure white before this fix and yellow after.

## Bug 3 — foliage shader detection regex too narrow

The foliage-name regex on line 332 covered tree/fern/grass/vine/branch/willow/
bush/shrub/hedge/bamboo/koru/treefern but missed several term families
common in Synty material names: `flower`, `sunflower`, `wildflower`,
`cropfield`, `crop`, `cover`, `card_`, `kite`, `leaves`. Materials with those
names fell through to the polygon shader and rendered without
breeze/wind/leaf-color params.

Verified against POLYGON Nature Biomes Meadow Forest: nine materials switch
from `polygon` → `foliage` with this regex change:
`Card_Sunflower_01`, `CropField_01`, `Flowers_Field_Variation`,
`Flowers_Flat_Mat_01`, `Ground_Cover_Mat_01`, `Kite_Mat_01`,
`Sunflowers_Mat_01`, `WildFlowers_02`, `WildFlowers_03`. Card_Tree_* were
already correctly handled via "tree".

### Known limitation

This regex extension does **not** by itself fix every flower-named material.
`WildFlowers_01` in Meadow Forest still resolves to `polygon` because
LOD-inheritance in `build_shader_cache` caches the LOD0 slot's shader for the
whole prefab, and `SM_Env_Wildflowers_01_LOD0` uses an unrelated material name
(`BASEMat_02_Saturated`) that no regex matches. That LOD-inheritance edge
case is a separate, larger fix not addressed here.

## Scope

- `COLOR_MAP_POLYGON`: `_ColorTint` addition is additive. Emission rename
  changes behavior for any existing converted material with a non-default
  `_EmissionColor` — output now matches Unity instead of being silent
  white. Worth a release-notes mention if cut as a new version.
- `COLOR_MAP_FOLIAGE`: `_Leaf_Noise_Large_Color` addition is additive.
- Regex extension is purely additive and only affects materials whose
  name matches one of the new terms.
- Particles, water, skydome, clouds, crystal maps untouched.

## Test plan

- [ ] Convert a Synty pack with a known non-white `_ColorTint` material
      (POLYGON Nature's `PolygonNature_Leaves_Base_Yellow.mat` is a clear
      case) and verify the output `.tres` has `shader_parameter/color_tint`
      matching the Unity value
- [ ] Convert any pack with a non-default `_EmissionColor` and verify the
      output writes `shader_parameter/emission_color_tint` (not
      `emission_color`)
- [ ] Convert Meadow Forest, verify `Card_Tree_Birch_02.tres` has the
      yellow `_Leaf_Noise_Large_Color` set on `leaf_noise_large_color`
- [ ] Convert Meadow Forest, verify the nine listed materials now use
      `foliage.gdshader` instead of `polygon.gdshader`
- [ ] Smoke-test conversion of a pack that uses none of these properties —
      output should be unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)